### PR TITLE
dereference symlinks with ncp so tools can watch changes

### DIFF
--- a/blumenkohl.js
+++ b/blumenkohl.js
@@ -24,7 +24,7 @@ var builder = new broccoli.Builder(tree);
 
 var broccoliWatcher = new Watcher(builder, {verbose: true});
 broccoliWatcher.on("change", function(hash) {
-  ncp(hash.directory, path.join(appRoot, destDir));
+  ncp(hash.directory, path.join(appRoot, destDir), { dereference: true }, () => {});
   console.log(clc.green("Build was successful: " + Math.round(hash.totalTime / 1e6) + "ms"));
 });
 


### PR DESCRIPTION
Thanks for the great tool!  I just set the option in the ncp call that would follow symlinks.  I was using lite-server to serve up the build and it wasn't detecting changes through the symlinks.
